### PR TITLE
Implemented Proxy

### DIFF
--- a/upload/src/addons/Kruzya/Telegram/Utils.php
+++ b/upload/src/addons/Kruzya/Telegram/Utils.php
@@ -49,10 +49,35 @@ class Utils {
     $token    = self::getBotToken();
     $client   = \XF::app()->http()->client();
 
+    $settings = [
+      'json'  => $body,
+    ];
+
+    $options = \XF::app()->options();
+    if ($options->telegramUseProxy) {
+      // get all settings.
+      $address  = $options->telegramProxyAddress;
+      $login    = $options->telegramProxyLogin;
+      $password = $options->telegramProxyPassword;
+
+      // check login exist.
+      if (empty($login))
+        $login = 'anonymous';
+      $credentials = $login;
+
+      // check password exist.
+      if (!empty($password))
+        $credentials .= ":{$password}";
+
+      // add credentials to proxy address.
+      $proxy = str_replace('://', "://$credentials@", $address);
+
+      // push to settings array.
+      $settings['proxy'] = $proxy;
+    }
+
     try {
-      $response = $client->post("https://api.telegram.org/bot{$token}/{$method}", [
-        'json'        => $body,
-      ]);
+      $response = $client->post("https://api.telegram.org/bot{$token}/{$method}", $settings);
 
       return json_decode($response->getBody(), true);
     } catch (RequestException $e) {

--- a/upload/src/addons/Kruzya/Telegram/_data/options.xml
+++ b/upload/src/addons/Kruzya/Telegram/_data/options.xml
@@ -4,4 +4,20 @@
     <default_value>0</default_value>
     <relation group_id="telegram" display_order="2000"/>
   </option>
+  <option option_id="telegramProxyAddress" edit_format="textbox" data_type="string">
+    <default_value>socks5h://185.231.246.111:5000</default_value>
+    <relation group_id="telegram" display_order="5100"/>
+  </option>
+  <option option_id="telegramProxyLogin" edit_format="textbox" data_type="string">
+    <default_value>telegram</default_value>
+    <relation group_id="telegram" display_order="5200"/>
+  </option>
+  <option option_id="telegramProxyPassword" edit_format="textbox" data_type="string">
+    <default_value>durov</default_value>
+    <relation group_id="telegram" display_order="5300"/>
+  </option>
+  <option option_id="telegramUseProxy" edit_format="onoff" data_type="string">
+    <default_value>0</default_value>
+    <relation group_id="telegram" display_order="5000"/>
+  </option>
 </options>

--- a/upload/src/addons/Kruzya/Telegram/_data/phrases.xml
+++ b/upload/src/addons/Kruzya/Telegram/_data/phrases.xml
@@ -6,7 +6,17 @@
   <phrase title="con_acc_telegram_bot_token_explain" version_id="2000010" version_string="2.0.0 Alpha"><![CDATA[Input here HTTP access token. It will be sent to BotFatner when creating the bot.]]></phrase>
   <phrase title="cron_entry.telegram_notifications" version_id="1005073" version_string="1.0.5.3"><![CDATA[[Telegram] Notifications Queue Worker]]></phrase>
   <phrase title="option.telegramFloodProtect" version_id="1004070" version_string="1.0.4"><![CDATA[Flood Protect]]></phrase>
+  <phrase title="option.telegramProxyAddress" version_id="1005072" version_string="1.0.5.2"><![CDATA[Proxy Address]]></phrase>
+  <phrase title="option.telegramProxyLogin" version_id="1005072" version_string="1.0.5.2"><![CDATA[Proxy Login]]></phrase>
+  <phrase title="option.telegramProxyPassword" version_id="1005072" version_string="1.0.5.2"><![CDATA[Proxy Password]]></phrase>
+  <phrase title="option.telegramUseProxy" version_id="1005072" version_string="1.0.5.2"><![CDATA[Use Proxy]]></phrase>
   <phrase title="option_explain.telegramFloodProtect" version_id="1004070" version_string="1.0.4"><![CDATA[Enable this if you want disable notifications for users automatically, if user don't allowed send messages. <br /><b>Note</b>: Telegram may return "fail" if can't send messages by technical reasons.]]></phrase>
+  <phrase title="option_explain.telegramProxyAddress" version_id="1005072" version_string="1.0.5.2"><![CDATA[Fill here address to Proxy Server.<br />
+<b>Note</b>: Address should contain protocol name, like <i>socks5h</i>.]]></phrase>
+  <phrase title="option_explain.telegramProxyLogin" version_id="1005072" version_string="1.0.5.2"><![CDATA[Fill here your username for Proxy Server, if this exists.<br />
+If this field leaved empty - we use <i>anonymous</i>.]]></phrase>
+  <phrase title="option_explain.telegramProxyPassword" version_id="1005072" version_string="1.0.5.2"><![CDATA[Fill here your username for Proxy Server, if this exists.]]></phrase>
+  <phrase title="option_explain.telegramUseProxy" version_id="1005072" version_string="1.0.5.2"><![CDATA[Enable this, if your hosting block any request for Telegram Bot API.]]></phrase>
   <phrase title="option_group.telegram" version_id="1003071" version_string="1.0.3.1"><![CDATA[Telegram]]></phrase>
   <phrase title="option_group_description.telegram" version_id="1003071" version_string="1.0.3.1"><![CDATA[Telegram Sync Settings]]></phrase>
   <phrase title="permission.telegram_notifications" version_id="1004070" version_string="1.0.4"><![CDATA[Receive notifications in Telegram]]></phrase>


### PR DESCRIPTION
Added Proxy support for requests to Telegram Bot API.
![proxy_settings](https://user-images.githubusercontent.com/12576822/43805372-91f59b98-9ab0-11e8-9c09-4c5f68aa3e8a.png)

**By default, proxy disabled**. Default values - my own proxy server for Telegram.
Uses `proxy` setting from Guzzle. More details - in [official Guzzle documentation](http://docs.guzzlephp.org/en/latest/request-options.html#proxy).

Closes #5.